### PR TITLE
Fix flakey cypress tests

### DIFF
--- a/cypress/integration/getTokenSilently.js
+++ b/cypress/integration/getTokenSilently.js
@@ -73,8 +73,6 @@ describe('getTokenSilently', function () {
 
   describe('when using refresh tokens', () => {
     it('retrieves an access token using a refresh token', () => {
-      cy.server();
-
       return whenReady().then(win => {
         cy.toggleSwitch('local-storage');
         cy.toggleSwitch('use-cache');
@@ -94,7 +92,6 @@ describe('getTokenSilently', function () {
             .should('have.length', 2);
 
           cy.wait('@tokenApiCheck').then(xhr => {
-            console.log(xhr);
             assert.equal(
               xhr.request.body.grant_type,
               'refresh_token',
@@ -106,8 +103,6 @@ describe('getTokenSilently', function () {
     });
 
     it('retrieves an access token for another audience using a refresh token', () => {
-      cy.server();
-
       return whenReady().then(win => {
         cy.toggleSwitch('local-storage');
         cy.toggleSwitch('use-cache');

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -51,6 +51,7 @@ Cypress.Commands.add('loginNoCallback', () => {
 });
 
 Cypress.Commands.add('resetTests', () => {
+  cy.server();
   cy.visit('http://localhost:3000');
   cy.get('#reset-config').click();
   cy.get('#logout').click();

--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -4,4 +4,4 @@ module.exports.shouldBe = (expected, actual) => expect(actual).to.eq(expected);
 module.exports.shouldNotBe = (expected, actual) =>
   expect(actual).to.not.eq(expected);
 module.exports.whenReady = () =>
-  cy.get('#loaded', { timeout: 5000 }).then(() => cy.window());
+  cy.get('#loaded', { timeout: 10000 }).then(() => cy.window());


### PR DESCRIPTION
Make sure `cy.server` goes before the first `cy.visit`
Extend the timeout (used to be 9 seconds before I inadvertently changed it to 5 in https://github.com/auth0/auth0-spa-js/commit/82807e383030d798962cf9eb89fd1354c3f2e174#diff-28d41bc70c5d0a2f8b839021cd236afe)

Works pretty consistently on my machine with this combo (was failing ~2 out of 10 times without these changes)

![image](https://user-images.githubusercontent.com/1299658/91541028-9a43b380-e913-11ea-8f35-df84ffe92bf7.png)
